### PR TITLE
[BUG] 설정 뷰에서 프로필수정, 비밀번호 수정뷰 화면전환시 백그라운드 컬러 투명인 버그 수정

### DIFF
--- a/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/SettingScene/SettingVC.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/SettingScene/SettingVC.swift
@@ -300,9 +300,11 @@ extension SettingVC: UITableViewDelegate {
             switch indexPath.row {
             case 0:
                 let changeImageVC = ChangeImageVC()
+                changeImageVC.view.backgroundColor = .white
                 self.navigationController?.pushViewController(changeImageVC, animated: true)
             case 1:
                 let changePasswordVC = ChangePasswordVC()
+                changePasswordVC.view.backgroundColor = .white
                 self.navigationController?.pushViewController(changePasswordVC, animated: true)
             default:
                 break


### PR DESCRIPTION
## 📌 관련 이슈
closed #267 

## 📌 변경 사항 및 이유


## 📌 PR Point
설정 뷰에서 프로필수정, 비밀번호 수정뷰 화면전환시 백그라운드 컬러를 white로 설정하여 넘겨줌으로써
화면전환시 백그라운드 컬러가 투명이어서 생기는 버그를 수정했습니다.


## 📌 참고 사항
