### PR TITLE
[FEAT] 둘러보기 시 접근 제한 기능 구현

### DIFF
--- a/ChaRo-iOS/ChaRo-iOS/Source/Extensions/UIViewController+.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Extensions/UIViewController+.swift
@@ -112,4 +112,11 @@ extension UIViewController {
         
     }
     
+    /// LoginSB의 루트 네비게이션 컨트롤러로 화면전환하는 메서드
+    public func presentToSignNC() {
+        guard let signNC = UIStoryboard(name: "Login", bundle: nil).instantiateViewController(withIdentifier: SignNC.className)
+                as? SignNC else { return }
+        signNC.modalPresentationStyle = .overFullScreen
+        self.present(signNC, animated: true, completion: nil)
+    }
 }

--- a/ChaRo-iOS/ChaRo-iOS/Source/Extensions/UIViewController+.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Extensions/UIViewController+.swift
@@ -33,6 +33,28 @@ extension UIViewController {
         self.present(alertViewController, animated: true, completion: completion)
     }
     
+    func makeRequestAlert(title: String,
+                          message: String,
+                          okTitle: String,
+                          okAction: ((UIAlertAction) -> Void)?,
+                          cancelTitle: String,
+                          cancelAction: ((UIAlertAction) -> Void)? = nil,
+                          completion: (() -> Void)? = nil) {
+        
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+        
+        let alertViewController = UIAlertController(title: title, message: message,
+                                                    preferredStyle: .alert)
+        
+        let cancelAction = UIAlertAction(title: cancelTitle, style: .default, handler: cancelAction)
+        alertViewController.addAction(cancelAction)
+        
+        let okAction = UIAlertAction(title: okTitle, style: .default, handler: okAction)
+        alertViewController.addAction(okAction)
+        
+        self.present(alertViewController, animated: true, completion: completion)
+    }
     
     func makeAlert(title: String,
                    message: String,

--- a/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/CreatePostScene/WrittingScene/CreatePostVC.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/CreatePostScene/WrittingScene/CreatePostVC.swift
@@ -39,7 +39,7 @@ final class CreatePostVC: UIViewController {
     private var itemProviders: [NSItemProvider] = []
     private var iterator: IndexingIterator<[NSItemProvider]>?
     private var titleSelectFlag: Bool = false // 제목 textfield 선택했는지 여부
-
+    private var isLogin: Bool = UserDefaults.standard.bool(forKey: Constants.UserDefaultsKey.isLogin)
 
     // MARK: UI
 
@@ -100,6 +100,7 @@ final class CreatePostVC: UIViewController {
       self.tableView.separatorStyle = .none
       self.tableView.dismissKeyboardWhenTappedAround()
       self.initCellHeight()
+      self.makeAlertWhenLookAround()
   }
 }
 
@@ -174,6 +175,16 @@ extension CreatePostVC {
             courseDesc: self.courseDesc,
             course: []
         )
+    }
+    
+    private func makeAlertWhenLookAround() {
+        if !isLogin {
+            makeRequestAlert(title: "로그인이 필요해요", message: "", okTitle: "로그인하기", okAction: { [weak self] _ in
+                self?.presentToSignNC()
+            }, cancelTitle: "취소", cancelAction: { [weak self] _ in
+                self?.dismiss(animated: true)
+            }, completion: nil)
+        }
     }
 }
 

--- a/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/HomeScene/HomeVC.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/HomeScene/HomeVC.swift
@@ -58,6 +58,7 @@ class HomeVC: UIViewController {
     private var notificationListData = BehaviorSubject<[NotificationListModel]>(value: [])
     private let bag = DisposeBag()
     private var notificationActivate: Bool?
+    private var isLogin: Bool = UserDefaults.standard.bool(forKey: Constants.UserDefaultsKey.isLogin)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -190,17 +191,30 @@ class HomeVC: UIViewController {
     }
     
     @objc func presentSearchPost() {
-        let nextVC = SearchPostVC()
-        let navigation = UINavigationController(rootViewController: nextVC)
-        navigation.modalPresentationStyle = .fullScreen
-        present(navigation, animated: true, completion: nil)
+        if isLogin {
+            let nextVC = SearchPostVC()
+            let navigation = UINavigationController(rootViewController: nextVC)
+            navigation.modalPresentationStyle = .fullScreen
+            present(navigation, animated: true, completion: nil)
+        } else {
+            // 로그인을 하지 않았을 때 - 둘러보기
+            makeRequestAlert(title: "로그인이 필요해요", message: "", okTitle: "로그인하기", okAction: { [weak self] _ in
+                self?.presentToSignNC()
+            }, cancelTitle: "취소")
+        }
     }
     
     @IBAction func notificationButtonClicked(_ sender: Any) {
-        
-        guard let notiVC = UIStoryboard(name: "Notification", bundle: nil).instantiateViewController(identifier: "NotificationVC") as? NotificationVC else {return}
-        
-        self.navigationController?.pushViewController(notiVC, animated: true)
+        if isLogin {
+            guard let notiVC = UIStoryboard(name: "Notification", bundle: nil).instantiateViewController(identifier: "NotificationVC") as? NotificationVC else {return}
+            
+            self.navigationController?.pushViewController(notiVC, animated: true)
+        } else {
+            // 로그인을 하지 않았을 때 - 둘러보기
+            makeRequestAlert(title: "로그인이 필요해요", message: "", okTitle: "로그인하기", okAction: { [weak self] _ in
+                self?.presentToSignNC()
+            }, cancelTitle: "취소")
+        }
     }
     
     private func bindNotificationData() {

--- a/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/HomeScene/HomeVC.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/HomeScene/HomeVC.swift
@@ -547,8 +547,14 @@ extension HomeVC: CollectionViewCellDelegate {
 //postID 넘기기 위한 Delegate 구현
 extension HomeVC: PostIdDelegate {
     func sendPostDetail(with postId: Int) {
-        let nextVC = PostDetailVC(postId: postId)
-        navigationController?.pushViewController(nextVC, animated: true)
+        if isLogin {
+            let nextVC = PostDetailVC(postId: postId)
+            navigationController?.pushViewController(nextVC, animated: true)
+        } else {
+            makeRequestAlert(title: "로그인이 필요해요", message: "", okTitle: "로그인하기", okAction: { [weak self] _ in
+                self?.presentToSignNC()
+            }, cancelTitle: "취소")
+        }
     }
 }
 

--- a/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/HomeScene/HomeVC.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/HomeScene/HomeVC.swift
@@ -505,33 +505,37 @@ extension HomeVC: IsSelectedCVCDelegate {
 
 extension HomeVC: SeeMorePushDelegate {
     func seeMorePushDelegate(data: Int) {
-        guard let smVC = UIStoryboard(name: "HomePost", bundle: nil).instantiateViewController(identifier: "HomePostVC") as? HomePostVC else {return}
-        
-        switch data {
-        case 3:
-            smVC.topText = "요즘 뜨는 드라이브 코스"
-            GetDetailDataService.value = "0"
-            GetNewDetailDataService.value = "0"
-            GetInfinityDetailDataService.identifier = "0"
-        case 4:
-            smVC.topText = customText
-            GetDetailDataService.value = "1?value=lake"
-            GetNewDetailDataService.value = "1?value=lake"
-            GetInfinityDetailDataService.identifier = "1"
-            GetInfinityDetailDataService.value = "?value=lake"
-        case 5:
-            smVC.topText = localText
-            GetDetailDataService.value = "2?value=busan"
-            GetNewDetailDataService.value = "2?value=busan"
-            GetInfinityDetailDataService.identifier = "2"
-            GetInfinityDetailDataService.value = "?value=busan"
-        default:
-            print("Error")
+        if isLogin {
+            guard let smVC = UIStoryboard(name: "HomePost", bundle: nil).instantiateViewController(identifier: "HomePostVC") as? HomePostVC else {return}
+            
+            switch data {
+            case 3:
+                smVC.topText = "요즘 뜨는 드라이브 코스"
+                GetDetailDataService.value = "0"
+                GetNewDetailDataService.value = "0"
+                GetInfinityDetailDataService.identifier = "0"
+            case 4:
+                smVC.topText = customText
+                GetDetailDataService.value = "1?value=lake"
+                GetNewDetailDataService.value = "1?value=lake"
+                GetInfinityDetailDataService.identifier = "1"
+                GetInfinityDetailDataService.value = "?value=lake"
+            case 5:
+                smVC.topText = localText
+                GetDetailDataService.value = "2?value=busan"
+                GetNewDetailDataService.value = "2?value=busan"
+                GetInfinityDetailDataService.identifier = "2"
+                GetInfinityDetailDataService.value = "?value=busan"
+            default:
+                print("Error")
+            }
+            self.navigationController?.pushViewController(smVC, animated: true)
+        } else {
+            makeRequestAlert(title: "로그인이 필요해요", message: "", okTitle: "로그인하기", okAction: { [weak self] _ in
+                self?.presentToSignNC()
+            }, cancelTitle: "취소")
         }
-        self.navigationController?.pushViewController(smVC, animated: true)
     }
-    
-    
 }
 
 extension HomeVC: CollectionViewCellDelegate {

--- a/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/HomeScene/HomeVC.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/HomeScene/HomeVC.swift
@@ -31,6 +31,7 @@ class HomeVC: UIViewController {
     var homeTableViewHeaderHeight: CGFloat = UIScreen.getDeviceWidth() * 517.0 / 375.0
     var headerView: UIView!
     private var bannerImageList: [UIImage] = []
+    private var currentNaviIconColorIsWhite: Bool = false
     
     enum BannerContent: String, CaseIterable {
         case seaDriveCource = "강릉 해변 드라이브 코스와 맛집"
@@ -111,7 +112,7 @@ class HomeVC: UIViewController {
         }
         headerView.frame = headerRect
     }
-
+    
     
     //서버 데이터 받아오는 부분
     func getServerData() {
@@ -228,12 +229,16 @@ class HomeVC: UIViewController {
             }
             
             self?.notificationActivate = isActivate
-            self?.setNaviBarNotificationItem(isActive: isActivate)
+            self?.setNaviBarNotificationItem(isActive: isActivate, isWhite: self?.currentNaviIconColorIsWhite ?? false)
         }).disposed(by: bag)
     }
     
-    private func setNaviBarNotificationItem(isActive: Bool) {
-        homeNavigationNotificationButton.setBackgroundImage(isActive ? ImageLiterals.icAlarmActiveWhite : ImageLiterals.icAlarmWhite, for: .normal) 
+    private func setNaviBarNotificationItem(isActive: Bool, isWhite: Bool) {
+        if isActive {
+            homeNavigationNotificationButton.setBackgroundImage(isWhite ? ImageLiterals.icAlarmActiveWhite : ImageLiterals.icAlarmActiveBlack, for: .normal)
+        } else {
+            homeNavigationNotificationButton.setBackgroundImage(isWhite ? ImageLiterals.icAlarmWhite : ImageLiterals.icAlarmBlack, for: .normal)
+        }
     }
 }
 
@@ -334,15 +339,17 @@ extension HomeVC: UITableViewDelegate {
     //MARK: ScrollViewDidScroll
     private func configureLogoImage(isWhite: Bool) {
         if isWhite {
+            currentNaviIconColorIsWhite = true
             homeNavigationLogo.image = ImageLiterals.icCharoLogoWhite
             homeNavigationSearchButton.setBackgroundImage(ImageLiterals.icSearchWhite, for: .normal)
             homeNavigationNotificationButton.setBackgroundImage(notificationActivate ?? false ? ImageLiterals.icAlarmActiveWhite :ImageLiterals.icAlarmWhite, for: .normal)
             navigationBottomView.isHidden = true
         } else {
+            currentNaviIconColorIsWhite = false
             homeNavigationLogo.image = ImageLiterals.icCharoLogo
             homeNavigationSearchButton.setBackgroundImage(ImageLiterals.icSearchBlack, for: .normal)
             homeNavigationNotificationButton.setBackgroundImage(notificationActivate ?? false ? ImageLiterals.icAlarmActiveBlack : ImageLiterals.icAlarmBlack, for: .normal)
-
+            
             navigationBottomView.isHidden = false
         }
     }

--- a/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/HomeScene/HomeVC.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/HomeScene/HomeVC.swift
@@ -233,8 +233,7 @@ class HomeVC: UIViewController {
     }
     
     private func setNaviBarNotificationItem(isActive: Bool) {
-        homeNavigationNotificationButton.rx.image()
-            .onNext(isActive ? ImageLiterals.icAlarmActiveWhite : ImageLiterals.icAlarmWhite)
+        homeNavigationNotificationButton.setBackgroundImage(isActive ? ImageLiterals.icAlarmActiveWhite : ImageLiterals.icAlarmWhite, for: .normal) 
     }
 }
 
@@ -337,16 +336,13 @@ extension HomeVC: UITableViewDelegate {
         if isWhite {
             homeNavigationLogo.image = ImageLiterals.icCharoLogoWhite
             homeNavigationSearchButton.setBackgroundImage(ImageLiterals.icSearchWhite, for: .normal)
-            if let noti = notificationActivate {
-                homeNavigationNotificationButton.rx.image().onNext(noti ? ImageLiterals.icAlarmActiveWhite :ImageLiterals.icAlarmWhite)
-            }
+            homeNavigationNotificationButton.setBackgroundImage(notificationActivate ?? false ? ImageLiterals.icAlarmActiveWhite :ImageLiterals.icAlarmWhite, for: .normal)
             navigationBottomView.isHidden = true
         } else {
             homeNavigationLogo.image = ImageLiterals.icCharoLogo
             homeNavigationSearchButton.setBackgroundImage(ImageLiterals.icSearchBlack, for: .normal)
-            if let noti = notificationActivate {
-                homeNavigationNotificationButton.rx.image().onNext(noti ? ImageLiterals.icAlarmActiveBlack :ImageLiterals.icAlarmBlack)
-            }
+            homeNavigationNotificationButton.setBackgroundImage(notificationActivate ?? false ? ImageLiterals.icAlarmActiveBlack : ImageLiterals.icAlarmBlack, for: .normal)
+
             navigationBottomView.isHidden = false
         }
     }

--- a/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/MyPageScene/MyPageVC.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/MyPageScene/MyPageVC.swift
@@ -12,13 +12,13 @@ import Then
 import Kingfisher
 
 class MyPageVC: UIViewController {
-//MARK: VAR
+    //MARK: VAR
     //var
     let userWidth = UIScreen.main.bounds.width
     let userheight = UIScreen.main.bounds.height
     var tabbarBottomConstraint: Int = 0
     
-    var isLogin: Bool = UserDefaults.standard.bool(forKey: Constants.UserDefaultsKey.isLogin) ?? false
+    var isLogin: Bool = UserDefaults.standard.bool(forKey: Constants.UserDefaultsKey.isLogin)
     
     private var userProfileData: [UserInformation] = []
     //var writenPostData: [MyPagePost] = []
@@ -52,8 +52,8 @@ class MyPageVC: UIViewController {
         $0.backgroundColor = UIColor.mainBlue
     }
     //팔로우 버튼하나 추가 하고, 밑에 컬뷰 하나 넣고 끝 내일 마무리 치기
-
-
+    
+    
     private let headerTitleLabel = UILabel().then {
         $0.textColor = UIColor.white
         $0.font = UIFont.notoSansMediumFont(ofSize: 17)
@@ -63,7 +63,7 @@ class MyPageVC: UIViewController {
     private let settingButton = UIButton().then {
         $0.setBackgroundImage(ImageLiterals.icSettingWhite , for: .normal)
         $0.addTarget(self, action: #selector(settingButtonClicked(_:)), for: .touchUpInside)
-
+        
     }
     
     private let userNameLabel = UILabel().then {
@@ -124,7 +124,7 @@ class MyPageVC: UIViewController {
         $0.textAlignment = .center
         $0.numberOfLines = 3
     }
-
+    
     
     //tabbarUI
     private let tabbarBackgroundView = UIView().then {
@@ -175,7 +175,7 @@ class MyPageVC: UIViewController {
     private let saveView = UIView().then {
         $0.backgroundColor = UIColor.white
     }
-
+    
     private var writeCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewFlowLayout.init())
         let layout:UICollectionViewFlowLayout = UICollectionViewFlowLayout.init()
@@ -199,7 +199,7 @@ class MyPageVC: UIViewController {
         return collectionView
     }()
     
-//MARK: ViewdidLoad
+    //MARK: ViewdidLoad
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         tabBarController?.tabBar.isHidden = false
@@ -225,7 +225,7 @@ class MyPageVC: UIViewController {
         }
     }
     
-//MARK: function
+    //MARK: function
     //탭바 쉬트 이동 및 버튼클릭시 애니메이션
     func setTabbarBottomViewMove() {
         var contentOffsetX = collectionScrollView.contentOffset.x
@@ -302,91 +302,99 @@ class MyPageVC: UIViewController {
             noSaveDataLabel.isHidden = false
         }
     }
-//MARK: Server
-//마이페이지 데이터 받아오는 함수
+    //MARK: Server
+    //마이페이지 데이터 받아오는 함수
     func getMypageData() {
         GetMyPageDataService.URL = Constants.myPageURL + "like/\(myId)"
         GetMyPageDataService.MyPageData.getRecommendInfo{ (response) in
-                   switch response
-                   {
-                   case .success(let data) :
-                       if let response = data as? MyPageDataModel {
-                           self.userProfileData = []
-                           self.writenPostDriveData = []
-                           self.savePostDriveData = []
-                           self.userProfileData.append(response.data.userInformation)
-                           self.writenPostDriveData.append(contentsOf: response.data.writtenPost.drive)
-                           self.savePostDriveData.append(contentsOf: response.data.savedPost.drive)
-                           self.setHeaderData()
-                           self.writeCollectionView.reloadData()
-                           self.saveCollectioinView.reloadData()
-                           self.isEmptyData()
-                       }
-                   case .requestErr(let message) :
-                       print("requestERR")
-                   case .pathErr :
-                       print("pathERR")
-                   case .serverErr:
-                       print("serverERR")
-                   case .networkFail:
-                       print("networkFail")
-                   }
-               }
+            switch response
+            {
+            case .success(let data) :
+                if let response = data as? MyPageDataModel {
+                    self.userProfileData = []
+                    self.writenPostDriveData = []
+                    self.savePostDriveData = []
+                    self.userProfileData.append(response.data.userInformation)
+                    self.writenPostDriveData.append(contentsOf: response.data.writtenPost.drive)
+                    self.savePostDriveData.append(contentsOf: response.data.savedPost.drive)
+                    self.setHeaderData()
+                    self.writeCollectionView.reloadData()
+                    self.saveCollectioinView.reloadData()
+                    self.isEmptyData()
+                }
+            case .requestErr(let message) :
+                print("requestERR")
+            case .pathErr :
+                print("pathERR")
+            case .serverErr:
+                print("serverERR")
+            case .networkFail:
+                print("networkFail")
+            }
+        }
     }
     
     func getInfinityData(addUrl: String, LikeOrNew: String) {
         delegate = self
         self.delegate?.startIndicator()
         MypageInfinityService.MyPageInfinityData.getRecommendInfo(userID: myId, addURL: addUrl,likeOrNew: LikeOrNew) { (response) in
-                   switch response
-                   {
-                   case .success(let data) :
-                       if let response = data as? MypageInfinityModel {
-                           if response.data.lastID == 0{
-                               self.isLast = true
-                               self.delegate?.endIndicator()
-                           }
-                           else {
-                               self.isLast = false
-                           }
-                           if self.isLast == false {
-                               self.writenPostDriveData.append(contentsOf: response.data.drive)
-                               self.writeCollectionView.reloadData()
-                               self.saveCollectioinView.reloadData()
-                               self.delegate?.endIndicator()
-                           }
-
-                       }
-                   case .requestErr(let message) :
-                       print("requestERR")
-                   case .pathErr :
-                       print("pathERR")
-                   case .serverErr:
-                       print("serverERR")
-                   case .networkFail:
-                       print("networkFail")
-                   }
-               }
+            switch response
+            {
+            case .success(let data) :
+                if let response = data as? MypageInfinityModel {
+                    if response.data.lastID == 0{
+                        self.isLast = true
+                        self.delegate?.endIndicator()
+                    }
+                    else {
+                        self.isLast = false
+                    }
+                    if self.isLast == false {
+                        self.writenPostDriveData.append(contentsOf: response.data.drive)
+                        self.writeCollectionView.reloadData()
+                        self.saveCollectioinView.reloadData()
+                        self.delegate?.endIndicator()
+                    }
+                    
+                }
+            case .requestErr(let message) :
+                print("requestERR")
+            case .pathErr :
+                print("pathERR")
+            case .serverErr:
+                print("serverERR")
+            case .networkFail:
+                print("networkFail")
+            }
+        }
     }
-
-
-
-//MARK: buttonClicked
-   @objc private func saveButtonClicked(_ sender: UIButton) {
-       collectionScrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
-       tabbarWriteButton.setImage(ImageLiterals.icWriteActive, for: .normal)
-       tabbarSaveButton.setImage(ImageLiterals.icSaveInactive, for: .normal)
+    
+    // MARK: buttonClicked
+    @objc private func saveButtonClicked(_ sender: UIButton) {
+        collectionScrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
+        tabbarWriteButton.setImage(ImageLiterals.icWriteActive, for: .normal)
+        tabbarSaveButton.setImage(ImageLiterals.icSaveInactive, for: .normal)
     }
+    
     @objc private func writeButtonClicked(_ sender: UIButton) {
         collectionScrollView.setContentOffset(CGPoint(x: userWidth, y: 0), animated: true)
         tabbarWriteButton.setImage(ImageLiterals.icWriteInactive, for: .normal)
         tabbarSaveButton.setImage(ImageLiterals.icSaveActive, for: .normal)
-     }
+    }
+    
     @objc private func settingButtonClicked(_ sender: UIButton) {
-        guard let setVC = UIStoryboard(name: "Setting", bundle: nil).instantiateViewController(withIdentifier: "SettingVC") as? SettingVC else {return}
-        
-        self.navigationController?.pushViewController(setVC, animated: true)
-     }
+        if isLogin {
+            // 로그인을 했을 때
+            guard let setVC = UIStoryboard(name: "Setting", bundle: nil).instantiateViewController(withIdentifier: "SettingVC") as? SettingVC else {return}
+            self.navigationController?.pushViewController(setVC, animated: true)
+        } else {
+            // 로그인을 하지 않았을 때 - 둘러보기
+            makeRequestAlert(title: "로그인이 필요해요", message: "", okTitle: "로그인하기", okAction: { [weak self] _ in
+                self?.presentToSignNC()
+            }, cancelTitle: "취소")
+        }
+    }
+    
     @objc private func followerButtonClicked(_ sender: UIButton) {
         guard let followVC = UIStoryboard(name: "FollowFollowing", bundle: nil).instantiateViewController(withIdentifier: "FollowFollwingVC") as? FollowFollwingVC else {return}
         if isLogin == true {
@@ -395,9 +403,12 @@ class MyPageVC: UIViewController {
             self.navigationController?.pushViewController(followVC, animated: true)
         }
         else {
-            self.makeAlert(title: "로그인", message: "로그인 하고 이용해 주세요", okAction: nil, completion: nil)
+            makeRequestAlert(title: "로그인이 필요해요", message: "", okTitle: "로그인하기", okAction: { [weak self] _ in
+                self?.presentToSignNC()
+            }, cancelTitle: "취소")
         }
-     }
+    }
+    
     @objc private func followingButtonClicked(_ sender: UIButton) {
         guard let followVC = UIStoryboard(name: "FollowFollowing", bundle: nil).instantiateViewController(withIdentifier: "FollowFollwingVC") as? FollowFollwingVC else {return}
         if isLogin == true {
@@ -406,23 +417,21 @@ class MyPageVC: UIViewController {
             self.navigationController?.pushViewController(followVC, animated: true)
         }
         else {
-            self.makeAlert(title: "로그인", message: "로그인 하고 이용해 주세요", okAction: nil, completion: nil)
-        }
-     }
-    @objc func nameLabelClicked(sender: UITapGestureRecognizer) {
-        guard let LoginVC = UIStoryboard(name: "Login", bundle: nil).instantiateViewController(withIdentifier: SNSLoginVC.identifier)
-                as? SNSLoginVC else {return}
-        let navController = UINavigationController(rootViewController: LoginVC)
-        
-        if isLogin == false {
-//요 녀석은 일단 이 뷰에 들어가면 빠져나올수가 없어서 잠시 빼놓겠습니다!
-            navController.modalPresentationStyle = .overFullScreen
-            self.present(navController, animated: true, completion: nil)
+            makeRequestAlert(title: "로그인이 필요해요", message: "", okTitle: "로그인하기", okAction: { [weak self] _ in
+                self?.presentToSignNC()
+            }, cancelTitle: "취소")
         }
     }
-
     
-//MARK: ScrollViewdidScroll
+    @objc func nameLabelClicked(sender: UITapGestureRecognizer) {
+        if isLogin == false {
+            makeRequestAlert(title: "로그인이 필요해요", message: "", okTitle: "로그인하기", okAction: { [weak self] _ in
+                self?.presentToSignNC()
+            }, cancelTitle: "취소")
+        }
+    }
+    
+    //MARK: ScrollViewdidScroll
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let writeContentHeigth = writeCollectionView.contentSize.height
         let saveContentHeigth = saveCollectioinView.contentSize.height
@@ -451,25 +460,25 @@ class MyPageVC: UIViewController {
             var likeOrNew = ""
             var addURL = ""
             if lastcount > 0 && scrollTriger == false {
-            scrollTriger = true
-            lastId = writenPostDriveData[lastcount-1].postID
-            lastFavorite = writenPostDriveData[lastcount-1].favoriteNum
-            
-            if currentState == "인기순" {
-                //print(lastId , "라스트 아이디", lastFavorite, "라스트 페이브릿" , "인기순")
-                likeOrNew = "like/"
-                addURL = "/write/\(lastId)/\(lastFavorite)"
-                //이거 릴리즈전에는 지울건데 지금은 더미가 부족해서 테스트 용으로 잠시 주석처리해놨슴니당 무한으로 즐기는 스크롤
-                //MypageInfinityService.addURL = "/write/11/0"
-                getInfinityData(addUrl: addURL, LikeOrNew: likeOrNew)
-
-            } else if currentState == "최신순" {
-                //print(lastId , "라스트 아이디", lastFavorite, "라스트 페이브릿", "최신순")
-                likeOrNew = "new/"
-                addURL = "/write/\(lastId)"
-                //MypageInfinityService.addURL = "/write/5/0"
-                getInfinityData(addUrl: addURL, LikeOrNew: likeOrNew)
-            }
+                scrollTriger = true
+                lastId = writenPostDriveData[lastcount-1].postID
+                lastFavorite = writenPostDriveData[lastcount-1].favoriteNum
+                
+                if currentState == "인기순" {
+                    //print(lastId , "라스트 아이디", lastFavorite, "라스트 페이브릿" , "인기순")
+                    likeOrNew = "like/"
+                    addURL = "/write/\(lastId)/\(lastFavorite)"
+                    //이거 릴리즈전에는 지울건데 지금은 더미가 부족해서 테스트 용으로 잠시 주석처리해놨슴니당 무한으로 즐기는 스크롤
+                    //MypageInfinityService.addURL = "/write/11/0"
+                    getInfinityData(addUrl: addURL, LikeOrNew: likeOrNew)
+                    
+                } else if currentState == "최신순" {
+                    //print(lastId , "라스트 아이디", lastFavorite, "라스트 페이브릿", "최신순")
+                    likeOrNew = "new/"
+                    addURL = "/write/\(lastId)"
+                    //MypageInfinityService.addURL = "/write/5/0"
+                    getInfinityData(addUrl: addURL, LikeOrNew: likeOrNew)
+                }
                 
             }
             //저장글 무한 스크롤
@@ -480,25 +489,25 @@ class MyPageVC: UIViewController {
             
             if lastcount > 0 && scrollTriger == false {
                 scrollTriger = true
-            lastId = savePostDriveData[lastcount-1].postID
-            lastFavorite = savePostDriveData[lastcount-1].favoriteNum
-            
-            if currentState == "인기순" {
-                //print(lastId , "라스트 아이디", lastFavorite, "라스트 페이브릿" , "인기순")
-                likeOrNew = "like/"
-                addURL = "/write/\(lastId)/\(lastFavorite)"
-                //이거 릴리즈전에는 지울건데 지금은 더미가 부족해서 테스트 용으로 잠시 주석처리해놨슴니당 무한으로 즐기는 스크롤
-                //MypageInfinityService.addURL = "/write/5/0"
-                getInfinityData(addUrl: addURL, LikeOrNew: likeOrNew)
-            } else if currentState == "최신순" {
-                //print(lastId , "라스트 아이디", lastFavorite, "라스트 페이브릿", "최신순")
-                likeOrNew = "new/"
-                addURL = "/write/\(lastId)"
-                //MypageInfinityService.addURL = "/write/5/0"
-                getInfinityData(addUrl: addURL, LikeOrNew: likeOrNew)
+                lastId = savePostDriveData[lastcount-1].postID
+                lastFavorite = savePostDriveData[lastcount-1].favoriteNum
+                
+                if currentState == "인기순" {
+                    //print(lastId , "라스트 아이디", lastFavorite, "라스트 페이브릿" , "인기순")
+                    likeOrNew = "like/"
+                    addURL = "/write/\(lastId)/\(lastFavorite)"
+                    //이거 릴리즈전에는 지울건데 지금은 더미가 부족해서 테스트 용으로 잠시 주석처리해놨슴니당 무한으로 즐기는 스크롤
+                    //MypageInfinityService.addURL = "/write/5/0"
+                    getInfinityData(addUrl: addURL, LikeOrNew: likeOrNew)
+                } else if currentState == "최신순" {
+                    //print(lastId , "라스트 아이디", lastFavorite, "라스트 페이브릿", "최신순")
+                    likeOrNew = "new/"
+                    addURL = "/write/\(lastId)"
+                    //MypageInfinityService.addURL = "/write/5/0"
+                    getInfinityData(addUrl: addURL, LikeOrNew: likeOrNew)
+                }
+                
             }
-            
-        }
         }
         
         if (writeCollectionView.contentOffset.y < writeContentHeigth - writeCollectionView.frame.height) {scrollTriger = false}
@@ -506,8 +515,8 @@ class MyPageVC: UIViewController {
         
         
     }
-//MARK: filterTableView
-        func setFilterViewLayout() {
+    //MARK: filterTableView
+    func setFilterViewLayout() {
         self.view.addSubview(filterView)
         filterView.isHidden = true
         filterView.snp.makeConstraints{
@@ -537,11 +546,11 @@ class MyPageVC: UIViewController {
             return index
         }
     }
-//MARK: CollectionViewLayout
+    //MARK: CollectionViewLayout
     func setCollectionViewLayout() {
         
         let collectionviewHeight  = userheight - (userheight * 0.27 + 130)
-                
+        
         collectionScrollView.delegate = self
         writeCollectionView.delegate = self
         writeCollectionView.dataSource = self
@@ -555,7 +564,7 @@ class MyPageVC: UIViewController {
         saveCollectioinView.registerCustomXib(xibName: "MyPagePostCVC")
         writeCollectionView.registerCustomXib(xibName: "HomePostDetailCVC")
         saveCollectioinView.registerCustomXib(xibName: "HomePostDetailCVC")
-             
+        
         
         self.view.addSubview(collectionScrollView)
         collectionScrollView.addSubview(writeView)
@@ -563,7 +572,7 @@ class MyPageVC: UIViewController {
         writeView.addSubview(writeCollectionView)
         saveView.addSubview(saveCollectioinView)
         
-       
+        
         collectionScrollView.snp.makeConstraints {
             $0.top.equalTo(tabbarBottomView.snp.bottom).offset(0)
             $0.trailing.equalTo(view).offset(0)
@@ -594,9 +603,9 @@ class MyPageVC: UIViewController {
             $0.leading.equalTo(saveView.snp.leading).offset(0)
             $0.trailing.equalTo(saveView.snp.trailing).offset(0)
         }
-       
+        
     }
-//MARK: TabbarLayout
+    //MARK: TabbarLayout
     func setTabbarLayout() {
         self.view.addSubview(tabbarBackgroundView)
         tabbarBackgroundView.addSubview(tabbarSaveButton)
@@ -643,7 +652,7 @@ class MyPageVC: UIViewController {
         
         
     }
-//MARK: HeaderViewLayout
+    //MARK: HeaderViewLayout
     
     func setHeaderLayout() {
         self.view.addSubview(headerBackgroundView)
@@ -725,11 +734,11 @@ class MyPageVC: UIViewController {
 
 extension MyPageVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout:
-                            UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+                        UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         if indexPath.row == 0 {
             return CGSize(width: userWidth-35, height: 42)
         } else {
-        return CGSize(width: collectionView.frame.width, height: 100)
+            return CGSize(width: collectionView.frame.width, height: 100)
         }
     }
 }
@@ -796,18 +805,18 @@ extension MyPageVC: UICollectionViewDataSource {
             } else {
                 let writenElement = writenPostDriveData[indexPath.row-1]
                 var writenTags = [writenElement.region, writenElement.theme,
-                            writenElement.warning ?? ""] as [String]
+                                  writenElement.warning ?? ""] as [String]
                 print(writenPostDriveData, "왜 안뜨냐?")
                 cell.setData(image: writenElement.image,
-                         title: writenElement.title,
-                         tagCount: writenTags.count, tagArr: writenTags,
-                         heart: writenElement.favoriteNum,
-                         save: writenElement.saveNum,
-                         year: writenElement.year,
-                         month: writenElement.month,
-                         day: writenElement.day,
-                         postID: writenElement.postID)
-            return cell
+                             title: writenElement.title,
+                             tagCount: writenTags.count, tagArr: writenTags,
+                             heart: writenElement.favoriteNum,
+                             save: writenElement.saveNum,
+                             year: writenElement.year,
+                             month: writenElement.month,
+                             day: writenElement.day,
+                             postID: writenElement.postID)
+                return cell
             }
         case 2:
             if(indexPath.row == 0) {
@@ -816,16 +825,16 @@ extension MyPageVC: UICollectionViewDataSource {
                 let saveElement = savePostDriveData[indexPath.row-1]
                 var saveTags = [saveElement.region, saveElement.theme, saveElement.warning ?? ""] as [String]
                 
-            cell.setData(image: savePostDriveData[indexPath.row-1].image,
-                         title: savePostDriveData[indexPath.row-1].title,
-                         tagCount:saveTags.count, tagArr: saveTags,
-                         heart:savePostDriveData[indexPath.row-1].favoriteNum,
-                         save: savePostDriveData[indexPath.row-1].saveNum,
-                         year: savePostDriveData[indexPath.row-1].year,
-                         month: savePostDriveData[indexPath.row-1].month,
-                         day: savePostDriveData[indexPath.row-1].day,
-                         postID: savePostDriveData[indexPath.row-1].postID)
-            return cell
+                cell.setData(image: savePostDriveData[indexPath.row-1].image,
+                             title: savePostDriveData[indexPath.row-1].title,
+                             tagCount:saveTags.count, tagArr: saveTags,
+                             heart:savePostDriveData[indexPath.row-1].favoriteNum,
+                             save: savePostDriveData[indexPath.row-1].saveNum,
+                             year: savePostDriveData[indexPath.row-1].year,
+                             month: savePostDriveData[indexPath.row-1].month,
+                             day: savePostDriveData[indexPath.row-1].day,
+                             postID: savePostDriveData[indexPath.row-1].postID)
+                return cell
             }
         default:
             return UICollectionViewCell()
@@ -855,9 +864,9 @@ extension MyPageVC: MenuClickedDelegate {
     }
 }
 extension MyPageVC{
-func dismissDropDownWhenTappedAround() {
+    func dismissDropDownWhenTappedAround() {
         let tap: UITapGestureRecognizer =
-            UITapGestureRecognizer(target: self, action: #selector(dismissDropDown))
+        UITapGestureRecognizer(target: self, action: #selector(dismissDropDown))
         tap.cancelsTouchesInView = false
         self.view.addGestureRecognizer(tap)
     }
@@ -872,7 +881,7 @@ extension MyPageVC: AnimateIndicatorDelegate {
         lottieView.isHidden = false
         lottieView.lottieView.play()
     }
-
+    
     func endIndicator() {
         lottieView.lottieView.stop()
         lottieView.isHidden = true

--- a/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/SettingScene/SettingVC.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/SettingScene/SettingVC.swift
@@ -199,14 +199,6 @@ extension SettingVC {
         }
     }
     
-    /// LoginSB의 루트 네비게이션 컨트롤러로 화면전환하는 메서드
-    private func presentToSignNC() {
-        guard let signNC = UIStoryboard(name: "Login", bundle: nil).instantiateViewController(withIdentifier: SignNC.className)
-                as? SignNC else { return }
-        signNC.modalPresentationStyle = .overFullScreen
-        self.present(signNC, animated: true, completion: nil)
-    }
-    
     @objc
     private func backButtonClicked(_ sender: UIButton) {
         self.navigationController?.popViewController(animated: true)

--- a/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/ThemeScene/ThemePostVC.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/ThemeScene/ThemePostVC.swift
@@ -38,6 +38,7 @@ class ThemePostVC: UIViewController {
     var currentState: String = "인기순"
     private var selectedTheme = ""
     private var selectedDriveList: [DriveElement] = []
+    private var isLogin: Bool = UserDefaults.standard.bool(forKey: Constants.UserDefaultsKey.isLogin)
     
     //MARK:- Constraint
     
@@ -270,8 +271,14 @@ extension ThemePostVC: ThemeNetworkDelegate {
 
 extension ThemePostVC: PostIdDelegate {
     func sendPostDetail(with postId: Int) {
-        let nextVC = PostDetailVC(postId: postId)
-        navigationController?.pushViewController(nextVC, animated: true)
+        if isLogin {
+            let nextVC = PostDetailVC(postId: postId)
+            navigationController?.pushViewController(nextVC, animated: true)
+        } else {
+            makeRequestAlert(title: "로그인이 필요해요", message: "", okTitle: "로그인하기", okAction: { [weak self] _ in
+                self?.presentToSignNC()
+            }, cancelTitle: "취소")
+        }
     }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #294 
  

## 📌 변경 사항 및 이유
- 확인, 취소의 title text를 설정하고, action method를 정의할 수 있는 requestAlert case를 추가했습니다.


## 📌 PR Point
- 유저가 로그인을 하지 않고 둘러보기를 할 때
    - `게시글 상세보기`, `게시글 작성하기`, `알림뷰 접근`, `검색뷰 접근`, `마이페이지의 설정뷰 접근`, `각각 더보기 뷰 접근`을 제한하는 기능을 구현했습니다.


## 📌 참고 사항

