### PR TITLE
[CHORE] Notification 권한 알럿 삭제 및 설정의 PhotoUI 권한 토글 기능을 보수합니다.

### DIFF
--- a/ChaRo-iOS/ChaRo-iOS.xcodeproj/project.pbxproj
+++ b/ChaRo-iOS/ChaRo-iOS.xcodeproj/project.pbxproj
@@ -235,9 +235,6 @@
 		7F7704F828A279B90077F8A2 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7F7704F728A279B90077F8A2 /* RxSwift */; };
 		7F7704FB28A27A130077F8A2 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 7F7704FA28A27A130077F8A2 /* GoogleSignIn */; };
 		7F7704FE28A27A8A0077F8A2 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 7F7704FD28A27A8A0077F8A2 /* Kingfisher */; };
-		7F77050128A27B5D0077F8A2 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 7F77050028A27B5D0077F8A2 /* FirebaseAnalytics */; };
-		7F77050328A27B5D0077F8A2 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 7F77050228A27B5D0077F8A2 /* FirebaseCrashlytics */; };
-		7F77050528A27B5D0077F8A2 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 7F77050428A27B5D0077F8A2 /* FirebaseMessaging */; };
 		7F950A2228664CF8005E5E5C /* FollowButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F950A2128664CF8005E5E5C /* FollowButton.swift */; };
 		7FC2455B2866008A00B3756F /* ExpendedImageVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC2455A2866008A00B3756F /* ExpendedImageVC.swift */; };
 		7FC2455D2866013000B3756F /* ExpendedImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC2455C2866013000B3756F /* ExpendedImageViewModel.swift */; };
@@ -555,14 +552,11 @@
 				7F0BED9528A16C4B00BB3A8F /* KakaoSDKUser in Frameworks */,
 				7F7704F128A279940077F8A2 /* Then in Frameworks */,
 				7F7704EB28A279420077F8A2 /* Alamofire in Frameworks */,
-				7F77050128A27B5D0077F8A2 /* FirebaseAnalytics in Frameworks */,
 				7F0BED8F28A16C4B00BB3A8F /* KakaoSDKCommonCore in Frameworks */,
 				7F7704FB28A27A130077F8A2 /* GoogleSignIn in Frameworks */,
 				7F0BED8B28A16C4B00BB3A8F /* KakaoSDKAuth in Frameworks */,
-				7F77050528A27B5D0077F8A2 /* FirebaseMessaging in Frameworks */,
 				7F0BED9128A16C4B00BB3A8F /* KakaoSDKShare in Frameworks */,
 				7F7704F428A279B90077F8A2 /* RxCocoa in Frameworks */,
-				7F77050328A27B5D0077F8A2 /* FirebaseCrashlytics in Frameworks */,
 				7F7704E828A279270077F8A2 /* SnapKit in Frameworks */,
 				7F7704FE28A27A8A0077F8A2 /* Kingfisher in Frameworks */,
 				7F7704F828A279B90077F8A2 /* RxSwift in Frameworks */,
@@ -1513,9 +1507,6 @@
 				7F7704F728A279B90077F8A2 /* RxSwift */,
 				7F7704FA28A27A130077F8A2 /* GoogleSignIn */,
 				7F7704FD28A27A8A0077F8A2 /* Kingfisher */,
-				7F77050028A27B5D0077F8A2 /* FirebaseAnalytics */,
-				7F77050228A27B5D0077F8A2 /* FirebaseCrashlytics */,
-				7F77050428A27B5D0077F8A2 /* FirebaseMessaging */,
 			);
 			productName = "ChaRo-iOS";
 			productReference = 3C71FEA326881DAA007E8EAD /* ChaRo-iOS.app */;
@@ -1576,7 +1567,6 @@
 				7F7704F228A279B90077F8A2 /* XCRemoteSwiftPackageReference "RxSwift" */,
 				7F7704F928A27A130077F8A2 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				7F7704FC28A27A8A0077F8A2 /* XCRemoteSwiftPackageReference "Kingfisher" */,
-				7F7704FF28A27B5D0077F8A2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 3C71FEA426881DAA007E8EAD /* Products */;
 			projectDirPath = "";
@@ -2209,14 +2199,6 @@
 				kind = branch;
 			};
 		};
-		7F7704FF28A27B5D0077F8A2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2299,21 +2281,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7F7704FC28A27A8A0077F8A2 /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
-		};
-		7F77050028A27B5D0077F8A2 /* FirebaseAnalytics */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7F7704FF28A27B5D0077F8A2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalytics;
-		};
-		7F77050228A27B5D0077F8A2 /* FirebaseCrashlytics */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7F7704FF28A27B5D0077F8A2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseCrashlytics;
-		};
-		7F77050428A27B5D0077F8A2 /* FirebaseMessaging */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7F7704FF28A27B5D0077F8A2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseMessaging;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ChaRo-iOS/ChaRo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ChaRo-iOS/ChaRo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,230 @@
+{
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "state" : {
+        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
+        "version" : "0.20220203.2"
+      }
+    },
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "8dd85aee02e39dd280c75eef88ffdb86eed4b07b",
+        "version" : "5.6.2"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "3d36a58a2b736f7bc499453e996a704929b25080",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "boringssl-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
+      "state" : {
+        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "7e80c25b51c2ffa238879b07fbfc5baa54bb3050",
+        "version" : "9.6.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "c1cfde8067668027b23a42c29d11c246152fe046",
+        "version" : "9.6.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
+        "version" : "9.2.0"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS.git",
+      "state" : {
+        "revision" : "9c9b36af86a4dd3da16048a36cf37351e63ccfe1",
+        "version" : "6.2.4"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "68ea347bdb1a69e2d2ae2e25cd085b6ef92f64cb",
+        "version" : "7.9.0"
+      }
+    },
+    {
+      "identity" : "grpc-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-ios.git",
+      "state" : {
+        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
+        "version" : "1.44.3-grpc"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "d4289da23e978f37c344ea6a386e5546e2466294",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "6dee0cde8a1b223737a5159e55e6b4ec16bbbdd9",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "branch" : "master",
+        "revision" : "8b968cfd71e3612dd43892910f8f8b8ca69cd51b"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk-rx",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk-rx",
+      "state" : {
+        "branch" : "master",
+        "revision" : "4ebe91e062bb4c95c502d1de63e4143240e82c43"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "26a5aee988318f1a57adc9b9c3e676ce318630a8"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+        "version" : "1.22.2"
+      }
+    },
+    {
+      "identity" : "lottie-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/airbnb/lottie-ios.git",
+      "state" : {
+        "revision" : "314537ec697719fa33a9d48210f4d06a463286d3",
+        "version" : "3.4.3"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "3e4e743631e86c8c70dbc6efdc7beaa6e90fd3bb",
+        "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "rxalamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxAlamofire.git",
+      "state" : {
+        "revision" : "9535b58695b91fb67f56d58d6fd0c76462d7743a",
+        "version" : "6.1.2"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "b4307ba0b6425c0ba4178e138799946c3da594f8",
+        "version" : "6.5.0"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit.git",
+      "state" : {
+        "revision" : "f222cbdf325885926566172f6f5f06af95473158",
+        "version" : "5.6.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+        "version" : "1.20.2"
+      }
+    },
+    {
+      "identity" : "then",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devxoul/Then.git",
+      "state" : {
+        "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a",
+        "version" : "3.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ChaRo-iOS/ChaRo-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ChaRo-iOS/ChaRo-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "abseil-cpp-swiftpm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
-      "state" : {
-        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
-        "version" : "0.20220203.2"
-      }
-    },
-    {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
@@ -28,66 +19,12 @@
       }
     },
     {
-      "identity" : "boringssl-swiftpm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
-      "state" : {
-        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
-        "version" : "0.9.1"
-      }
-    },
-    {
-      "identity" : "firebase-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
-      "state" : {
-        "revision" : "cbaa7ce7063d5ab22414962ec63366ccbba26034",
-        "version" : "9.4.1"
-      }
-    },
-    {
-      "identity" : "googleappmeasurement",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleAppMeasurement.git",
-      "state" : {
-        "revision" : "f54f60d0164d887e1174fa51ab2efe48a8e9d178",
-        "version" : "9.3.0"
-      }
-    },
-    {
-      "identity" : "googledatatransport",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleDataTransport.git",
-      "state" : {
-        "revision" : "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
-        "version" : "9.2.0"
-      }
-    },
-    {
       "identity" : "googlesignin-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleSignIn-iOS.git",
       "state" : {
         "revision" : "9450e779619fc184d360c9f7ce61023587f7e1f4",
         "version" : "6.2.2"
-      }
-    },
-    {
-      "identity" : "googleutilities",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleUtilities.git",
-      "state" : {
-        "revision" : "f4abe56ce62a779e64b525eb133c8fc2a84bbc1f",
-        "version" : "7.7.1"
-      }
-    },
-    {
-      "identity" : "grpc-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-ios.git",
-      "state" : {
-        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
-        "version" : "1.44.3-grpc"
       }
     },
     {
@@ -136,15 +73,6 @@
       }
     },
     {
-      "identity" : "leveldb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/leveldb.git",
-      "state" : {
-        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
-        "version" : "1.22.2"
-      }
-    },
-    {
       "identity" : "lottie-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-ios.git",
@@ -154,30 +82,12 @@
       }
     },
     {
-      "identity" : "nanopb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/nanopb.git",
-      "state" : {
-        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
-        "version" : "2.30909.0"
-      }
-    },
-    {
       "identity" : "ohhttpstubs",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
       "state" : {
         "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
         "version" : "9.1.0"
-      }
-    },
-    {
-      "identity" : "promises",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/promises.git",
-      "state" : {
-        "revision" : "3e4e743631e86c8c70dbc6efdc7beaa6e90fd3bb",
-        "version" : "2.1.1"
       }
     },
     {
@@ -205,15 +115,6 @@
       "state" : {
         "revision" : "f222cbdf325885926566172f6f5f06af95473158",
         "version" : "5.6.0"
-      }
-    },
-    {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "fa0fcd43f272a260e7f734f23e6dc55e16fcae0a",
-        "version" : "1.19.1"
       }
     },
     {

--- a/ChaRo-iOS/ChaRo-iOS/Resource/Info.plist
+++ b/ChaRo-iOS/ChaRo-iOS/Resource/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string></string>
-	<key>NSCameraUsageDescription</key>
-	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -53,7 +49,11 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string></string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string></string>
+	<key>NSPhotoLibraryUsageDescription</key>
 	<string></string>
 	<key>UIAppFonts</key>
 	<array>
@@ -91,7 +91,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
-		<string>remote-notification</string>
 		<string>voip</string>
 	</array>
 	<key>UILaunchStoryboardName</key>

--- a/ChaRo-iOS/ChaRo-iOS/Source/Models/SettingDataModel.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Models/SettingDataModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import UIKit
+import PhotosUI
 
 // MARK: - SettingDataModel
 struct SettingDataModel {
@@ -63,7 +64,9 @@ extension SettingSection {
     var settingData: [SettingDataModel] {
         switch self {
         case .accessAllow:
-            return [SettingDataModel(titleString: "사진", isToggle: true, toggleData: true)]
+            let authorizationStatus = PHPhotoLibrary.authorizationStatus()
+            let toggleStatus = (authorizationStatus == .authorized || authorizationStatus == .limited) ? true : false
+            return [SettingDataModel(titleString: "사진", isToggle: true, toggleData: toggleStatus)]
         case .account:
             return [SettingDataModel(titleString: "프로필 수정", titleLabelColor: UIColor.black),
                     SettingDataModel(titleString: "비밀번호 수정", titleLabelColor: UIColor.black),

--- a/ChaRo-iOS/ChaRo-iOS/Source/Support/AppDelegate.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Support/AppDelegate.swift
@@ -8,37 +8,15 @@
 import UIKit
 import GoogleSignIn
 import KakaoSDKCommon
-import Firebase
-import FirebaseMessaging
 import UserNotifications
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var window: UIWindow?
-    let gcmMessageIDKey = "gcm.message_id"
     
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
-        FirebaseApp.configure()
-        Messaging.messaging().delegate = self
-        
-        // [START register_for_notifications]
-        if #available(iOS 10.0, *) {
-            UNUserNotificationCenter.current().delegate = self
-            
-            let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
-            UNUserNotificationCenter.current().requestAuthorization(
-                options: authOptions,
-                completionHandler: {_, _ in })
-            application.registerForRemoteNotifications()
-        } else {
-            let settings: UIUserNotificationSettings =
-                UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
-            application.registerUserNotificationSettings(settings)
-            application.registerForRemoteNotifications()
-        }
         
         // [END register_for_notifications]
         KakaoSDK.initSDK(appKey: "fe470f9e3a4348f2b8dad52d2014efcc")
@@ -74,55 +52,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-}
-
-extension AppDelegate : UNUserNotificationCenterDelegate {
-    
-    // 앱이 foreground상태일 때, 알림이 온 경우 어떻게 표시할 것인지 처리
-    func userNotificationCenter(_ center: UNUserNotificationCenter,
-                                willPresent notification: UNNotification,
-                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        let userInfo = notification.request.content.userInfo
-        
-        if let messageID = userInfo[gcmMessageIDKey] {
-            print("Message ID: \(messageID)")
-        }
-        
-        print(userInfo)
-        
-        completionHandler([[.alert, .sound]])
-    }
-    
-    // push가 온 경우 처리. 앱을 실행한 적이 있을 때 처리되는 곳
-    func userNotificationCenter(_ center: UNUserNotificationCenter,
-                                didReceive response: UNNotificationResponse,
-                                withCompletionHandler completionHandler: @escaping () -> Void) {
-        
-        // Print message ID.
-        let userInfo = response.notification.request.content.userInfo
-        if let messageID = userInfo[gcmMessageIDKey] {
-            print("Message ID: \(messageID)")
-        }
-        
-        print(userInfo)
-        
-        if response.actionIdentifier == UNNotificationDismissActionIdentifier {
-            print ("Message Closed")
-        }
-        else if response.actionIdentifier == UNNotificationDefaultActionIdentifier {
-            print ("푸시 메시지 클릭 했을 때")
-        }
-        completionHandler()
-    }
-}
-
-extension AppDelegate: MessagingDelegate {
-    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        print("Firebase registration token: \(String(describing: fcmToken))")
-        
-        let dataDict:[String: String] = ["token": fcmToken ?? ""]
-        NotificationCenter.default.post(name: Notification.Name("FCMToken"), object: nil, userInfo: dataDict)
-        UserDefaults.standard.set(fcmToken, forKey: "fcmToken")
     }
 }

--- a/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/SettingScene/SettingVC.swift
+++ b/ChaRo-iOS/ChaRo-iOS/Source/Views/VCs/SettingScene/SettingVC.swift
@@ -45,10 +45,15 @@ final class SettingVC: UIViewController {
         configureUI()
         configureTableView()
         configureButtonAddTarget()
+        addNotificationObserver()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         self.tabBarController?.tabBar.isHidden = true
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        removeNotificationObserver()
     }
 }
 
@@ -180,23 +185,14 @@ extension SettingVC {
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
     
+    /// Notification Observer를 제거하는 메서드
+    private func removeNotificationObserver() {
+        NotificationCenter.default.removeObserver(UIApplication.willEnterForegroundNotification)
+    }
+    
     /// 앱 foreground로 진입했을 때 tableView의 section을 reload하는 메서드(토글 관련)
     @objc func willEnterForeground() {
         settingTableView.reloadSections(IndexSet(integer: 0), with: .automatic)
-    }
-    
-    /// 사진 접근 설정 상태를 토글에 반영하는 메서드
-    private func setPhotoSwitchStatus(_ toggle: UISwitch) {
-        DispatchQueue.main.async {
-            switch PHPhotoLibrary.authorizationStatus(for: .readWrite) {
-            case .authorized:
-                toggle.isOn = true
-            case .limited, .restricted, .denied, .notDetermined:
-                toggle.isOn = false
-            default:
-                break
-            }
-        }
     }
     
     @objc


### PR DESCRIPTION
## 📌 관련 이슈
closed #304 
  

## 📌 변경 사항 및 이유
- Firebase package 제거: 더이상 Firebase-Messaging 기능을 사용하지 않기도 하고, 현재 당장은 Analytics, Crashlystics 기능을 사용하지 않는 것 같아서 제거해두었습니다. 


## 📌 PR Point
- 푸시알림 권한 알럿 및 푸시알림 관련 코드를 모두 삭제했습니다.
- 설정뷰의 사진 접근 권한 토글과 접근 권한 허용상태를 연동했습니다.

